### PR TITLE
Alternative diagram for initial/terminal objects

### DIFF
--- a/doc/02_categories.md
+++ b/doc/02_categories.md
@@ -198,9 +198,9 @@ An object $x \in \mathcal{C}$ is \textbf{terminal} if for all $a \in \mathcal{C}
 \begin{figure}[H]
 \centering
 \begin{tikzcd}
-  &a \arrow[dr]&  \\
-i\arrow[ur] \arrow[rr, shift left] \arrow[dr] & & t \arrow[ll, shift left]\\
-  &b \arrow[ur] &
+  &a \arrow[dr] \arrow[dl, shift right] &  \\
+i\arrow[ur, shift right] \arrow[rr] \arrow[dr] & & t \arrow[dl, shift right]\\
+  &b \arrow[ur, shift right] &
 \end{tikzcd}
 \end{figure}
 Here, $i$ is initial, and $t$ is terminal.


### PR DESCRIPTION
In the original diagram, all objects are both initial and terminal. I think the idea was to show that terminal objects can still have outgoing arrows, and initial objects can still have incoming arrows. But maybe it would be clearer to have a diagram where the initial and terminal objects aren't isomorphic.

On the other hand, now that I've drawn this out, I'm not sure it is much of an improvement! So take it or leave it, no hard feelings either way :)