### PR TITLE
Fix typo in Products, coproducts and ADTs.

### DIFF
--- a/doc/04_products.md
+++ b/doc/04_products.md
@@ -67,7 +67,7 @@ A & & B
 \end{tikzcd}
 \end{figure}
 
-Consider any element $v \in V$. It gets mapped to $f(v) \in A$, and $g(v) \in B$. Let $q: v \mapsto (f(v), g(v))$, then $(p_1 \circ f)(v) = f(v)$, and thus $p_1 \circ f = f$. Similarly $p_2 \circ g = g$.
+Consider any element $v \in V$. It gets mapped to $f(v) \in A$, and $g(v) \in B$. Let $q: v \mapsto (f(v), g(v))$, then $(p_1 \circ q)(v) = f(v)$, and thus $p_1 \circ q = f$. Similarly $p_2 \circ q = g$.
 
 Indeed, we have constructed an arrow that makes the above diagram commute. It is also clear that this is the \emph{only arrow} that satisfies this, so we conclude that $A \times B$ is the product of $A$ and $B$ in the category \textbf{Set}. Another example of a product of sets would be $B \times A$, which is cannonically isomorphic to $A \times B$ (the isomorphism corresponds to 'swapping' the elements, which is its own inverse).
 \end{example}


### PR DESCRIPTION
In subsection Products, I believe `p_1` and `p_2` should be composed with `q` instead of `f` and `g` .