### PR TITLE
Fix typo in pullback definition

### DIFF
--- a/doc/09_f_algebras.md
+++ b/doc/09_f_algebras.md
@@ -231,7 +231,7 @@ we have a unique map $\bar{f}$ such that the following diagram commutes.
 \begin{figure}[H]
 \centering
 \begin{tikzcd}
-a \arrow[rd, "\bar{f}"] \arrow[rdd, bend right, "f_2"'] \arrow[rrd, bend left, "f_1"]& & \\
+a \arrow[rd, "\bar{f}"] \arrow[rdd, bend right, "f_1"'] \arrow[rrd, bend left, "f_2"]& & \\
 & p \arrow[r, "p_2"] \arrow[d, "p_1"'] & y \arrow[d, "t"] \\
 & x \arrow[r, "s"'] & z
 \end{tikzcd}


### PR DESCRIPTION
Hello! I am very much enjoying the book. In chapter 8, I believe there is a typo in the definition of pullback. Specifically, `f_1` and `f_2` are swapped from the above diagram. I was not able to generate the PDF to verify that my solution works since I receive an "undefined control sequence" error (and I am not too knowledgeable of LaTeX). Regardless, I hope you will check the definition and verify that the fix is indeed correct. Thanks!