### PR TITLE
Minor fix for product diagram.

### DIFF
--- a/doc/04_products.md
+++ b/doc/04_products.md
@@ -49,7 +49,7 @@ For an example with numbers:
 8 & 8 \arrow[l, "\times 1"] \arrow[r, "\times 2"'] & 16
 \end{tikzcd}
 \end{figure}
-$$4 = 2 \times 2,~8 = 4 \times 2.$$
+$$4 = 1 \times 4,~8 = 2 \times 4.$$
 This seems to indicate that in 'some category related to numbers' (in fact, precisely the category of natural numbers with arrows to their multiples, that we gave as an example in the first chapter), the product would correspond to the gcd!
 
 


### PR DESCRIPTION
Hi there!

In the page 24, Product section, Chapter 3 you define:
`f = p1 o q` and `g = p2 o q`
However in the following example you put:
`4 = 2 x 2` and `8 = 4 x 2`
But the arrow form `2` to `8`, which is `q`, has the value `x4`, and arrow from `8` to `8`, which is `p1`, has the value `x1`, so it should be `4 = 1 x 4` instead of `4 = 2 x 2` (If I understood well).

For the same reason I changed `g = 4 x 2` to `g = 2 x 4`, I think if you keep the order will be more understandable.

Cheers! :slightly_smiling_face: 